### PR TITLE
feat: SkeletalFloorAdjuster

### DIFF
--- a/Editor/FloorAdjusterPlugin.cs
+++ b/Editor/FloorAdjusterPlugin.cs
@@ -1,4 +1,7 @@
-﻿using nadena.dev.ndmf;
+﻿using System;
+using System.Linq;
+using nadena.dev.ndmf;
+using UnityEditor;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 
@@ -17,15 +20,21 @@ namespace Narazaka.VRChat.FloorAdjuster.Editor
             InPhase(BuildPhase.Transforming).AfterPlugin("nadena.dev.modular-avatar").Run(nameof(FloorAdjuster), ctx =>
             {
                 var floorAdjuster = ctx.AvatarRootObject.GetComponentInChildren<FloorAdjuster>();
-                if (floorAdjuster == null) return;
+                if (floorAdjuster != null) { RunFloorAdjuster(ctx, floorAdjuster); return; }
 
-                var descriptor = ctx.AvatarRootObject.GetComponentInChildren<VRCAvatarDescriptor>();
-                descriptor.ViewPosition += Vector3.up * floorAdjuster.Height;
-
-                AdjustArmature(floorAdjuster, descriptor);
-
-                UnityEngine.Object.DestroyImmediate(floorAdjuster);
+                var skeletalFloorAdjuster = ctx.AvatarRootObject.GetComponentInChildren<SkeletalFloorAdjuster>();
+                if (skeletalFloorAdjuster != null) { RunSkeletalFloorAdjuster(ctx, skeletalFloorAdjuster); return; }
             });
+        }
+
+        private void RunFloorAdjuster(BuildContext ctx, FloorAdjuster floorAdjuster)
+        {
+            var descriptor = ctx.AvatarRootObject.GetComponentInChildren<VRCAvatarDescriptor>();
+            descriptor.ViewPosition += Vector3.up * floorAdjuster.Height;
+
+            AdjustArmature(floorAdjuster, descriptor);
+
+            UnityEngine.Object.DestroyImmediate(floorAdjuster);
         }
 
         void AdjustArmature(FloorAdjuster floorAdjuster, VRCAvatarDescriptor descriptor)
@@ -40,5 +49,36 @@ namespace Narazaka.VRChat.FloorAdjuster.Editor
             hips.localScale = hips.localScale / armatureScale;
             descriptor.ViewPosition += Vector3.forward * zDiff;
         }
+
+
+        private static void RunSkeletalFloorAdjuster(BuildContext ctx, SkeletalFloorAdjuster skeletalFloorAdjuster)
+        {
+            var descriptor = ctx.AvatarRootObject.GetComponentInChildren<VRCAvatarDescriptor>();
+            var animator = ctx.AvatarRootObject.GetComponent<Animator>();
+
+            var floorDiff = -1 * skeletalFloorAdjuster.transform.position.y;
+
+
+            var adjustAvatar = UnityEngine.Object.Instantiate(animator.avatar);
+            var sAdjustTargetAvatar = new SerializedObject(adjustAvatar);//AvatarBuilder から作り直す実装もしてみたけど、うまくできる方法が全く分からなかった。
+
+            //アバターのルートモーションの大きさを変えることで Humanoid としての初期位置を変えることで高さが変わる。
+            var avatarScale = sAdjustTargetAvatar.FindProperty("m_Avatar.m_Human.data.m_Scale");
+            avatarScale.floatValue += floorDiff;
+
+            //ビューポジションも IKPose か TPose の影響を受けるのでその影響の時のために補正。
+            //IKPose も TPose もデフォルトの物であれば真上にしかルート移動が存在しないの Y 軸のみの補正で問題がない。
+            descriptor.ViewPosition += Vector3.up * floorDiff;
+
+
+            sAdjustTargetAvatar.ApplyModifiedProperties();
+
+            animator.avatar = adjustAvatar;
+            adjustAvatar.name += "-SkeletalFloorAdjusted";
+
+            AssetDatabase.AddObjectToAsset(adjustAvatar, ctx.AssetContainer);
+            UnityEngine.Object.DestroyImmediate(skeletalFloorAdjuster);
+        }
+
     }
 }

--- a/Editor/SkeletalFloorAdjusterEditor.cs
+++ b/Editor/SkeletalFloorAdjusterEditor.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+
+namespace Narazaka.VRChat.FloorAdjuster.Editor
+{
+    [CustomEditor(typeof(SkeletalFloorAdjuster))]
+    public class SkeletalFloorAdjusterEditor : UnityEditor.Editor
+    {
+        static Color s_fColor = new Color(0.5f, 0.5f, 0.5f, 0.1f);
+        static Color s_oColor = Color.white;
+        Vector3[] rectBuffer = new Vector3[4];
+        void OnSceneGUI()
+        {
+            var sfa = target as SkeletalFloorAdjuster;
+            var pos = sfa.transform.position;
+            rectBuffer[0] = pos + new Vector3(0.5f, 0, 0.5f);
+            rectBuffer[1] = pos + new Vector3(0.5f, 0, -0.5f);
+            rectBuffer[2] = pos + new Vector3(-0.5f, 0, -0.5f);
+            rectBuffer[3] = pos + new Vector3(-0.5f, 0, 0.5f);
+            Handles.DrawSolidRectangleWithOutline(rectBuffer, s_fColor, s_oColor);
+        }
+    }
+}

--- a/Editor/SkeletalFloorAdjusterEditor.cs.meta
+++ b/Editor/SkeletalFloorAdjusterEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 440e4ee156ea46f4583ff679535e328f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/SkeletalFloorAdjuster.cs
+++ b/SkeletalFloorAdjuster.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+using VRC.SDKBase;
+
+namespace Narazaka.VRChat.FloorAdjuster
+{
+    public class SkeletalFloorAdjuster : MonoBehaviour, IEditorOnly
+    {
+    }
+}

--- a/SkeletalFloorAdjuster.cs.meta
+++ b/SkeletalFloorAdjuster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bd99fd6c0640c6418b069efe05cbc70
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
アーマチュアのスケールをいじる方式も悪くはないですが...アーマチュア配下でかつ Hip 配下ではない場合にスケールが変わってしまうので、それを回避できる Animator にある Unity の Avatar から Skeleton をいじる形のアジャスターを作ってみました！

Unity の非公開な部分を無理やりいじっているので Unity がこの部分に変更を加えたら壊れますがそれ以外にデメリットのない方法です！